### PR TITLE
Migrations log table, and view to see all migrations status.

### DIFF
--- a/source/db_migrations/0000_setup_migrations.sql
+++ b/source/db_migrations/0000_setup_migrations.sql
@@ -1,0 +1,12 @@
+/* To log database migrations & status. */
+CREATE TABLE `wr_db_changelog` (
+    `timestamp` datetime NOT NULL,
+    `version` varchar(64) NOT NULL,
+    `status` varchar(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT
+    INTO `wr_db_changelog`
+        (timestamp, version, status)
+    VALUES
+        (NOW(), '0000', 'complete');

--- a/source/web_root/includes/views/desktop/custom/migrations.php
+++ b/source/web_root/includes/views/desktop/custom/migrations.php
@@ -1,0 +1,126 @@
+<?php
+
+	function get_last_completed_migration_id(){
+		global $dbConnection;
+
+		$query = "
+		SELECT
+			version
+		FROM
+			wr_db_changelog
+		WHERE
+			status='complete'
+		ORDER BY
+			timestamp DESC
+		LIMIT
+			1
+		;";
+
+		$result = $dbConnection->query($query) or die (
+			'Unable to execute: ' . $query . ' : ' . $dbConnection->error
+		);
+
+		$actual_result = null;
+
+		foreach($result as $row) {
+			$actual_result = $row['version'];
+		}
+
+		$result->free();
+
+		return $actual_result;
+
+
+	}
+
+
+	function display_migration_log() {
+		global $dbConnection;
+
+		echo '<h1>Migration Log</h1>';
+
+		$columns = ['timestamp', 'version', 'status'];
+
+		$query = 'SELECT ' . join(', ', $columns) . ' from wr_db_changelog;';
+
+		$result = $dbConnection->query($query) or die ('Unable to execute: ' . $query . ' : ' . $dbConnection->error );
+
+		echo '<table class="table table-hover table-condensed"><thead><tr>';
+		foreach ($columns as $column) {
+			echo '<td>' . $column . '</td>';
+		}
+		echo '</thead><tbody>';
+
+		foreach($result as $row) {
+			echo '<tr>';
+			foreach ($columns as $column) {
+				echo '<td>' . $row[$column] . '</td>';
+			}
+			echo '</tr>';
+		}
+		echo '</tbody></table>';
+
+		$result->free();
+
+	}
+
+	function display_pending_migrations($latest_number) {
+		$migrations_dir = __DIR__ . '/../../../../../db_migrations/';
+
+		echo ' looking in: ' . $migrations_dir;
+
+		$dir = opendir($migrations_dir);
+
+		$possible_migrations = array();
+
+		if ($dir !== false) {
+
+			$count = 0;
+
+			while (false !== ($entry = readdir($dir)) && $count< 1000) {
+				if ($entry != "." && $entry != "..") {
+					if (preg_match('/(\d\d\d\d)_(.*).sql/', $entry, $matches)) {
+						$possible_migrations[(int) $matches[1]] =  $entry;
+					}
+				}
+				$count++;
+			}
+			closedir($dir);
+		} else {
+			echo 'Cannot open directory.';
+		}
+
+		echo '<h3>All defined migrations</h3>';
+
+		echo '<pre>';
+		for($i=0;$i<9999;$i++) {
+			if ($possible_migrations[$i]) {
+				echo "$i - $possible_migrations[$i]";
+				if ($i <= $latest_number) {
+					echo ' - complete';
+				}
+				echo "\n";
+			} else {
+				break;
+			}
+		}
+		echo '</pre>';
+	}
+
+	// Display Content:
+
+	if (!$logged_in) {
+		echo 'Private';
+	} else {
+		display_migration_log();
+		$latest_number = get_last_completed_migration_id();
+		echo "<b>Latest complete:</b> $latest_number\n<br>\n";
+		display_pending_migrations($latest_number);
+	}
+
+?>
+<!--
+<form method="POST">
+<input name="run" value="Run Migrations" type="submit">
+</form>
+-->


### PR DESCRIPTION
- Create a table for logging database state & migrations
- A view for admins to see the migrations.

## Problems:

1. Having the files as straight ready-to-go SQL means that the table prefix is hard-coded.
2. The table prefix is hardcoded currently into the view as well.
3. Would it make sense (or is it giving too much permissions?) to allow running migrations from the admin? Is that a stupid idea?


## And...

For right now, I think we just say the prefix is hard-coded.  It's already hard-coded (I think) in one place already.  and it's not worth the added complexity right now of making it more flexible.