### PR TITLE
Configurable default logo

### DIFF
--- a/source/web_root/includes/views/desktop/shared/page_top.php
+++ b/source/web_root/includes/views/desktop/shared/page_top.php
@@ -142,7 +142,7 @@
 		// logo
 			echo "        <div id='logo' class='col-xs-12 col-sm-3 col-md-3 col-lg-3'>\n";
 			echo "          <h1 class='hidden'>" . htmlspecialchars($tl->settings['Name of this application'], ENT_QUOTES) . "</h1>\n";
-			echo "          <a href='/'><img src='" . (@$tl->page['domain_alias']['destination_url'] && file_exists($tl->page['domain_alias']['destination_url']) ? '/' . $tl->page['domain_alias']['destination_url'] : "/resources/img/logo.png") . "' border='0' class='img-responsive' alt='" . htmlspecialchars($tl->settings['Name of this application'], ENT_QUOTES) . "' /></a>\n";
+			echo "          <a href='/'><img src='" . (@$tl->page['domain_alias']['destination_url'] && file_exists($tl->page['domain_alias']['destination_url']) ? '/' . $tl->page['domain_alias']['destination_url'] : $tl->defaultHeaderLogo) . "' border='0' class='img-responsive' alt='" . htmlspecialchars($tl->settings['Name of this application'], ENT_QUOTES) . "' /></a>\n";
 			echo "        </div><!-- logo -->\n\n";
 	
 		// header

--- a/source/web_root/initialize.php
+++ b/source/web_root/initialize.php
@@ -19,6 +19,7 @@
 		$tl->backEndLibraries =		[];
 		$tl->frontEndLibraries =	[];
 		$tl->initialize =			[];
+		$tl->defaultHeaderLogo = '/resources/img/logo.png';
 
 		// autoload configuration files
 			if ($tl->initialize['handle'] = opendir(__DIR__ . '/../config/autoload/.')) {


### PR DESCRIPTION
# Source:

https://app.forecast.it/project/P-211/workflow/T12100

# Description:

Makes the default header logo configurable in code.

To update this, in `config/autoload/settings.php` add:

```php
$tl->defaultHeaderLogo = '/resources/msf-logo.jpg';
```

or whatever other file you've uploaded.

