### PR TITLE
Uploads for response tab, and other tweaks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ You should then be able to visit the site at http://localhost/ (127.0.0.1)
 ?>
 ```
 
+
+# Local migrations:
+
+You can run the database migrations manually locally with
+
+```shell
+	mysql -u root wikirumours < source/db_migrations/migration_name.sql
+```
+
 # Setup and installation
 
 The following steps are required to install and start using an

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -443,7 +443,13 @@
 			global $form; // the CMS form renderer...
 
 			return $form->row(
-				$fieldtype, $fieldname, $this->data[$fieldname], false, $label?:$fieldname, $css_class, ...$extra_args
+				$fieldtype, // type
+				$fieldname, // name
+				$this->data[$fieldname], // value
+				false, // mandatory
+				$label?:$fieldname, // label
+				$css_class, // css class
+				...$extra_args // options, max_length, otherAttributes, truncateLabel, eventHandlers
 			) . $this->render_error($fieldname);
 
 		}

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -473,6 +473,7 @@
 			'response_completion_date',
 			'response_completed',
 			'response_outcomes',
+			'response_uploads',
 		];
 
 		public function __construct($rumour, $relevantUsers) {
@@ -480,6 +481,7 @@
 			$this->relevantUsers = $relevantUsers;
 
 			$this->data = array();
+			$this->data['response_uploads'] = [];
 			$this->injest($this->rumour);
 		}
 
@@ -520,6 +522,7 @@
 			$response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:');
 			$response_form .= $this->render_field('response_completed', 'checkbox', 'Completed', '');
 			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Outcomes:');
+			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',  [null, null, ['destination_path' => '/tmp/TODO/']]);
 
 			// TODO - create a new 'date_with_picker' in tidal_lock/0-5/helpers/class.form.php
 

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -441,6 +441,15 @@
 			 */
 
 			global $form; // the CMS form renderer...
+			global $tl;
+
+			/* if (!isset($this->data[$fieldname])) { */
+			/* 	$this->data[$fieldname] = ['post_path']; */
+			/* } */
+
+			$tl->page['console'] .= $fieldname .  ' = ' . json_encode($extra_args) . "\n";
+
+			
 
 			return $form->row(
 				$fieldtype, // type
@@ -483,6 +492,19 @@
 			$this->data = array();
 			$this->data['response_uploads'] = [];
 			$this->injest($this->rumour);
+
+			// First upload to `trash`, move any actually desired ones into the correct place on save:
+			$this->temporary_upload_files_dir = 'trash/';
+
+			// TODO - make $FILE_UPLOAD_PATH a global
+			/* $FILE_UPLOAD_PATH = __DIR__ . '/../../../uploads'; */
+			$FILE_UPLOAD_PATH = '/srv/web_root/uploads';
+			$this->upload_files_dir = $FILE_UPLOAD_PATH . '/rumour_response_attachments';
+
+			// debugging:
+			print_r(glob($FILE_UPLOAD_PATH . '/*'));
+			print_r(glob($this->upload_files_dir .  '*'));
+
 		}
 
 		public function clean_response_who($value) {
@@ -522,7 +544,14 @@
 			$response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:');
 			$response_form .= $this->render_field('response_completed', 'checkbox', 'Completed', '');
 			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Outcomes:');
-			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',  [null, null, ['destination_path' => '/tmp/TODO/']]);
+			// WIP:
+			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',
+				[null, null, ['destination_path' => $this->temporary_upload_files_dir]]
+			);
+			$response_form .= "<h4>Current existant attachments:</h4>";
+			$response_form .= explode(',',  $this->get_attachments());
+			$response_form .= print_r($this->get_attachments(), true);
+			// /WIP
 
 			// TODO - create a new 'date_with_picker' in tidal_lock/0-5/helpers/class.form.php
 
@@ -533,7 +562,68 @@
 		}
 
 		public function save() {
+			// TODO - Do file uploads saving - deleted files need deleting?
+			// TODO - Remove 'response_uploads' from $this->data?
+			$response_uploads = $this->data['response_uploads'];	
+			print_r($response_uploads);
+			print_r($this->data);
+			print_r("POST:::\n\n\n<br>");
+			print_r($_POST);
+			exit(1);
+			unset($this->data['response_uploads']);
 			updateDb('rumours', $this->data, array('rumour_id'=>$this->rumour['rumour_id']), null, null, null, null, 1);
+			$this->data['response_uploads'] = $response_uploads;
+
+		}
+
+		public function get_attachments() {
+			global $directory_manager;
+
+			if (file_exists($self->upload_files_dir)) {
+				return $directory_manager->read('uploads/rumour_attachments/' . $self->rumour->public_id, false, false, true);
+			} else {
+				return [];
+			}
+
+		}
+
+		public function save_uploads() {
+			// Uses $_POST directly...
+			if (@$_POST['file_response_uploads']) {
+				foreach ($_POST['file_response_uploads'] as $uploadedFile) {
+					$filename = substr($uploadedFile, strrpos($uploadedFile, '/') + 1);
+					$uploadedFile = __DIR__ . '/../../../../' . $uploadedFile;
+					$destinationPath = 'uploads/rumour_response_attachments/' . $this->rumour->public_id;
+					if (!file_exists($destinationPath)) mkdir($destinationPath);
+					$success = rename($uploadedFile, $destinationPath . '/' . $filename);
+					if (!$success || !file_exists($destinationPath . '/' . $filename)) {
+						$tl->page['error'] .= "Unable to retrieve uploaded file for some reason. ";
+					}
+				}
+			}
+
+			if (file_exists($this->upload_files_dir)) {
+				$attachments = $directory_manager->read($this->upload_files_dir, false, false, true);
+
+				if (count($attachments)) {
+					for ($counter = 0; $counter < count($attachments); $counter++) {
+						$should_delete_attachment = isset($_POST['delete_response_uploads_' . $counter]);
+						$attachment_filepath = $_POST['delete_response_uploads_filepath_' . $counter];
+
+						// TODO - sanity check $attachment_filepath before deleteing.
+						// This should be ONLY the filename - and any `../` type things stripped out,
+						// and instead it should add the $self->upload_files_dir here.
+
+						if ($should_delete_attachment) {
+							$success = @unlink ($attachment_filepath);
+							if (!$success || file_exists($attachment_filepath)) {
+								$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
+							}
+						}
+					}
+				}
+			}
+
 		}
 
 	}

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -601,8 +601,8 @@
 			'response_what',
 			'response_who',
 			'response_start_date',
-			'response_duration_weeks',
-			'response_completion_date',
+			/* 'response_duration_weeks', */
+			/* 'response_completion_date', */
 			'response_completed',
 			'response_outcomes',
 			'response_uploads',
@@ -626,6 +626,20 @@
 			$FILE_UPLOAD_PATH = '/srv/web_root/uploads';
 			$this->upload_files_dir = $FILE_UPLOAD_PATH . '/rumour_response_attachments/' . $this->rumour['public_id'] . '/';
 
+		}
+
+		public function is_empty() {
+			/* Used by tab header to ask if there's any data here... */
+			foreach($this->data as $row) {
+				if ($row) {
+					return False;
+				}
+				if ($this->get_attachments($this->upload_files_dir)) {
+					return False;
+				}
+			}
+				
+			return True;
 		}
 
 		public function clean_response_who($value) {
@@ -663,7 +677,7 @@
 			/* $response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:'); */
 			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Intended Outcomes:');
 			$response_form .= $this->render_field('response_completed', 'checkbox', 'Completed', '');
-			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',
+			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Attachments:', 'form-control',
 				[null, null, ['destination_path' => $this->temporary_upload_files_dir]]
 			);
 

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -577,13 +577,13 @@
 			 * links, with "[x] Delete" checkboxes and filenames, suitable for use with 
 			 * delete_selected_uploaded_files
 			 * */
-			$html = "<ul>";
+			$html = '<ul class="list-group">';
 			foreach ($attachments as $index => $attachment) {
 				$filename = basename($attachment);
-				$html .= '<li>';
-				$html .= '<input type="checkbox" name="delete_' . $field_name . '_' . $index . '"> Delete</input> ';
+				$html .= '<li class="list-group-item">';
 				$html .= '<input type="hidden" name="delete_' . $field_name . '_filepath_' . $index . '" value="' . $filename . '">';
 				$html .= '<a target=_"blank" href="' . $attachments_base_url . $filename . '">' . $filename . '</a>';
+				$html .= '<span class="pull-right"><input type="checkbox" name="delete_' . $field_name . '_' . $index . '"> Delete</input></span>';
 				$html .= '</li>';
 			}
 			$html .= "</ul>";
@@ -659,8 +659,8 @@
 			$response_form .= $this->render_field('response_what', 'textarea', 'What:');
 			$response_form .= $this->render_field('response_who', 'select', 'Who:', 'form-control select2', [$this->relevantUsers]);
 			$response_form .= $this->render_field('response_start_date', 'date', 'Start Date:');
-			$response_form .= $this->render_field('response_duration_weeks', 'number', 'Duration (in weeks):');
-			$response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:');
+			/* $response_form .= $this->render_field('response_duration_weeks', 'number', 'Duration (in weeks):'); */
+			/* $response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:'); */
 			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Intended Outcomes:');
 			$response_form .= $this->render_field('response_completed', 'checkbox', 'Completed', '');
 			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',
@@ -669,12 +669,15 @@
 
 			$current_attachments = $this->get_attachments($this->upload_files_dir);
 			if ($current_attachments) {
-				$response_form .= "<h4>Current attachments:</h4>";
+				$response_form .= '<div class="form-group">';
+				$response_form .= '<label class="col-lg-3 col-md-3 col-sm-4 col-xs-12 control-label sr-only">Current attachments:</label>';
+				$response_form .= '<div class="col-lg-9 col-md-9 col-sm-8 col-xs-12">';
 				$response_form .= $this->render_attachments_list(
 					'response_uploads', // base field_name
 					$current_attachments, // attachment files
 					'/uploads/rumour_response_attachments/'  . $this->rumour['public_id'] . '/' // URL base for files
 				);
+				$response_form .= '</div></div>';
 			}
 
 			// TODO - create a new 'date_with_picker' in tidal_lock/0-5/helpers/class.form.php

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -447,10 +447,6 @@
 			/* 	$this->data[$fieldname] = ['post_path']; */
 			/* } */
 
-			$tl->page['console'] .= $fieldname .  ' = ' . json_encode($extra_args) . "\n";
-
-			
-
 			return $form->row(
 				$fieldtype, // type
 				$fieldname, // name
@@ -469,7 +465,119 @@
 	}
 
 
-	class ResponseForm extends BaseForm {
+	class BaseFormWithUploads extends BaseForm {
+		public $temporary_upload_files_dir;
+		public $temporary_upload_files_abspath;
+		
+		public function get_attachments($uploadsPath) {
+			/* Helper method to return list of files in a path. */
+			global $directory_manager;
+
+			if (file_exists($uploadsPath)) {
+				return $directory_manager->read($uploadsPath , false, false, true);
+			} else {
+				return [];
+			}
+
+		}
+
+
+		public function save_uploads($field_name, $destinationPath) {
+			/*
+			 * Given a base $field_name, and location to save new files to,
+			 * find all the files which have been uploaded to the `temporary_upload_files_dir`
+			 * and move them to $destinationPath.
+			 * */
+
+			global $tl;
+			// Uses $_POST directly...
+
+			if (@$_POST['file_' . $field_name]) {
+				foreach ($_POST['file_' . $field_name] as $uploadedFile) {
+					$filename = basename($uploadedFile);
+					$uploadedFile = $this->temporary_upload_files_abspath . '/' . $filename;
+
+					// Create directory for this rumour, if required:
+					if (!file_exists($destinationPath)) {
+						mkdir($destinationPath);
+					}
+					// Try to move the file into that directory:
+					$success = rename($uploadedFile, $destinationPath . '/' . $filename);
+					if (!$success || !file_exists($destinationPath . '/' . $filename)) {
+						$tl->page['error'] .= "Unable to retrieve uploaded file for some reason. ";
+					}
+				}
+			}
+		}
+
+		public function delete_selected_uploaded_files($field_name, $uploadsPath) {
+			/* 
+			 * Given a base $field_name, and a location where uploads are stored,
+			 * delete any uploaded files which are mentioned by `delete_${field_name}_...` fields.
+			 *
+			 * Use with $this->render_attachments_list to generate correct HTML fields.
+			 * */
+			global $directory_manager;
+			global $tl;
+			// Uses $_POST directly...
+			
+			// TODO - should this actually move them to a trash dir instead of deleting?
+
+			if (file_exists($uploadsPath)) {
+				$attachments = $directory_manager->read($uploadsPath, false, false, true);
+
+				if (count($attachments)) {
+					for ($counter = 0; $counter < count($attachments); $counter++) {
+						$should_delete_attachment = isset($_POST['delete_'. $field_name .'_' . $counter]);
+						$attachment_filepath = $_POST['delete_'. $field_name .'_filepath_' . $counter];
+						$attachment_filepath = basename($attachment_filepath);
+
+						if (!strlen($attachment_filepath)) {
+							$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
+							continue;
+						}
+
+						$attachment_filepath = $uploadsPath . $attachment_filepath;
+
+						if (!is_file($attachment_filepath)) {
+							$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
+							continue;
+						}
+
+						if ($should_delete_attachment) {
+							$success = @unlink ($attachment_filepath);
+							if (!$success || file_exists($attachment_filepath)) {
+								$tl->page['error'] .= "Unable to delete attachment: " . $attachment_filepath;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		function render_attachments_list($field_name, $attachments, $attachments_base_url) {
+			/* 
+			 * Given a base $field_name, a list of $attachments (file names) and the base URL
+			 * where user-facing links to the downloads should go, generate a list of attachment
+			 * links, with "[x] Delete" checkboxes and filenames, suitable for use with 
+			 * delete_selected_uploaded_files
+			 * */
+			$html = "<ul>";
+			foreach ($attachments as $index => $attachment) {
+				$filename = basename($attachment);
+				$html .= '<li>';
+				$html .= '<input type="checkbox" name="delete_' . $field_name . '_' . $index . '"> Delete</input> ';
+				$html .= '<input type="hidden" name="delete_' . $field_name . '_filepath_' . $index . '" value="' . $filename . '">';
+				$html .= '<a target=_"blank" href="' . $attachments_base_url . $filename . '">' . $filename . '</a>';
+				$html .= '</li>';
+			}
+			$html .= "</ul>";
+
+			return $html;
+		}
+	}
+
+	class ResponseForm extends BaseFormWithUploads {
 		private $rumour;
 		private $relevantUsers;
 
@@ -545,20 +653,15 @@
 			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',
 				[null, null, ['destination_path' => $this->temporary_upload_files_dir]]
 			);
-			$current_attachments = $this->get_attachments();
+
+			$current_attachments = $this->get_attachments($this->upload_files_dir);
 			if ($current_attachments) {
 				$response_form .= "<h4>Current attachments:</h4>";
-				$response_form .= "<ul>";
-				$uploads_path = '/uploads/rumour_response_attachments/' . $this->rumour['public_id'] . '/';
-				foreach ($current_attachments as $index => $attachment) {
-					$filename = basename($attachment);
-					$response_form .= '<li>';
-					$response_form .= '<input type="checkbox" name="delete_response_uploads_' . $index . '"> Delete</input> ';
-					$response_form .= '<input type="hidden" name="delete_response_uploads_filepath_' . $index . '" value="' . $filename . '">';
-					$response_form .= '<a href="' . $uploads_path . $filename . '">' . $filename . '</a>';
-					$response_form .= '</li>';
-				}
-				$response_form .= "</ul>";
+				$response_form .= $this->render_attachments_list(
+					'response_uploads', // base field_name
+					$current_attachments, // attachment files
+					'/uploads/rumour_response_attachments/'  . $this->rumour['public_id'] . '/' // URL base for files
+				);
 			}
 
 			// TODO - create a new 'date_with_picker' in tidal_lock/0-5/helpers/class.form.php
@@ -572,90 +675,15 @@
 		public function save() {
 			$response_uploads = $this->data['response_uploads'];	
 			// First delete any files which have been selected for deletion:
-			$this->delete_selected_uploaded_files();
+			$this->delete_selected_uploaded_files('response_uploads', $this->upload_files_dir);
 			// And now move in any new files from the temporary upload directory:
-			$this->save_uploads();
+			$this->save_uploads(
+				'response_uploads', // field name
+				$this->upload_files_dir // destinationPath
+			);
 			unset($this->data['response_uploads']);
 			updateDb('rumours', $this->data, array('rumour_id'=>$this->rumour['rumour_id']), null, null, null, null, 1);
 			$this->data['response_uploads'] = $response_uploads;
 
-
 		}
-
-		public function get_attachments() {
-			global $directory_manager;
-
-			if (file_exists($this->upload_files_dir)) {
-				return $directory_manager->read($this->upload_files_dir , false, false, true);
-			} else {
-				return [];
-			}
-
-		}
-
-
-		public function save_uploads() {
-			global $directory_manager;
-			global $tl;
-			// Uses $_POST directly...
-
-			if (@$_POST['file_response_uploads']) {
-				foreach ($_POST['file_response_uploads'] as $uploadedFile) {
-					$filename = basename($uploadedFile);
-					$uploadedFile = $this->temporary_upload_files_abspath . '/' . $filename;
-					$destinationPath = 'uploads/rumour_response_attachments/' . $this->rumour['public_id'];
-
-					// Create directory for this rumour, if required:
-					if (!file_exists($destinationPath)) {
-						mkdir($destinationPath);
-					}
-					// Try to move the file into that directory:
-					$success = rename($uploadedFile, $destinationPath . '/' . $filename);
-					if (!$success || !file_exists($destinationPath . '/' . $filename)) {
-						$tl->page['error'] .= "Unable to retrieve uploaded file for some reason. ";
-					}
-				}
-			}
-		}
-
-		public function delete_selected_uploaded_files() {
-			global $directory_manager;
-			global $tl;
-			// Uses $_POST directly...
-			
-			// TODO - should this actually move them to a trash dir instead of deleting?
-
-			if (file_exists($this->upload_files_dir)) {
-				$attachments = $directory_manager->read($this->upload_files_dir, false, false, true);
-
-				if (count($attachments)) {
-					for ($counter = 0; $counter < count($attachments); $counter++) {
-						$should_delete_attachment = isset($_POST['delete_response_uploads_' . $counter]);
-						$attachment_filepath = $_POST['delete_response_uploads_filepath_' . $counter];
-						$attachment_filepath = basename($attachment_filepath);
-
-						if (!strlen($attachment_filepath)) {
-							$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
-							continue;
-						}
-
-						$attachment_filepath = $this->upload_files_dir . $attachment_filepath;
-
-						if (!is_file($attachment_filepath)) {
-							$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
-							continue;
-						}
-
-						if ($should_delete_attachment) {
-							$success = @unlink ($attachment_filepath);
-							if (!$success || file_exists($attachment_filepath)) {
-								$tl->page['error'] .= "Unable to delete attachment: " . $attachment_filepath;
-							}
-						}
-					}
-				}
-			}
-
-		}
-
 	}

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -466,8 +466,23 @@
 
 
 	class BaseFormWithUploads extends BaseForm {
+		/* 
+		 * This extends the BaseForm with functionality for handling file uploads & deletions,
+		 * using the same system as the rest of the site, but hopefully a bit cleaner / more
+		 * re-usable logic.
+		 *
+		 * Files are uploaded initially to the `$this->temporary_upload_files_dir` - and then
+		 * moved into a final uploads path (can be different per field).
+		 *
+		 * To handle deleting, a list of delete checkboxes & hidden fields are added
+		 * to the form - with names which tie them together so the logic here knows which
+		 * selected files should be deleted.
+		 *
+		 * */
 		public $temporary_upload_files_dir;
 		public $temporary_upload_files_abspath;
+		// TODO - Could having a single temporary_upload_files_dir be a problem with
+		//        multiple files with the same name being uploaded to different fields???
 		
 		public function get_attachments($uploadsPath) {
 			/* Helper method to return list of files in a path. */
@@ -630,8 +645,6 @@
 			 */
 			global $form; // the CMS form renderer...
 
-			// TODO - for each field display any errors.
-
 			$response_form = '';
 			$response_form .= $form->start('responseForm', '', 'post');
 
@@ -648,8 +661,8 @@
 			$response_form .= $this->render_field('response_start_date', 'date', 'Start Date:');
 			$response_form .= $this->render_field('response_duration_weeks', 'number', 'Duration (in weeks):');
 			$response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:');
+			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Intended Outcomes:');
 			$response_form .= $this->render_field('response_completed', 'checkbox', 'Completed', '');
-			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Outcomes:');
 			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',
 				[null, null, ['destination_path' => $this->temporary_upload_files_dir]]
 			);

--- a/source/web_root/includes/controllers/custom/rumour.php
+++ b/source/web_root/includes/controllers/custom/rumour.php
@@ -495,15 +495,13 @@
 
 			// First upload to `trash`, move any actually desired ones into the correct place on save:
 			$this->temporary_upload_files_dir = 'trash/';
+			// This stupid ../../.. thing needed because it's hard coded into the file upload widget code...
+			$this->temporary_upload_files_abspath = realpath(__DIR__ . '/../../../../' . $this->temporary_upload_files_dir);
 
 			// TODO - make $FILE_UPLOAD_PATH a global
 			/* $FILE_UPLOAD_PATH = __DIR__ . '/../../../uploads'; */
 			$FILE_UPLOAD_PATH = '/srv/web_root/uploads';
-			$this->upload_files_dir = $FILE_UPLOAD_PATH . '/rumour_response_attachments';
-
-			// debugging:
-			print_r(glob($FILE_UPLOAD_PATH . '/*'));
-			print_r(glob($this->upload_files_dir .  '*'));
+			$this->upload_files_dir = $FILE_UPLOAD_PATH . '/rumour_response_attachments/' . $this->rumour['public_id'] . '/';
 
 		}
 
@@ -544,14 +542,24 @@
 			$response_form .= $this->render_field('response_completion_date', 'date', 'Completion Date:');
 			$response_form .= $this->render_field('response_completed', 'checkbox', 'Completed', '');
 			$response_form .= $this->render_field('response_outcomes', 'textarea', 'Outcomes:');
-			// WIP:
 			$response_form .= $this->render_field('response_uploads', 'file_dropzone', 'Uploads:', 'form-control',
 				[null, null, ['destination_path' => $this->temporary_upload_files_dir]]
 			);
-			$response_form .= "<h4>Current existant attachments:</h4>";
-			$response_form .= explode(',',  $this->get_attachments());
-			$response_form .= print_r($this->get_attachments(), true);
-			// /WIP
+			$current_attachments = $this->get_attachments();
+			if ($current_attachments) {
+				$response_form .= "<h4>Current attachments:</h4>";
+				$response_form .= "<ul>";
+				$uploads_path = '/uploads/rumour_response_attachments/' . $this->rumour['public_id'] . '/';
+				foreach ($current_attachments as $index => $attachment) {
+					$filename = basename($attachment);
+					$response_form .= '<li>';
+					$response_form .= '<input type="checkbox" name="delete_response_uploads_' . $index . '"> Delete</input> ';
+					$response_form .= '<input type="hidden" name="delete_response_uploads_filepath_' . $index . '" value="' . $filename . '">';
+					$response_form .= '<a href="' . $uploads_path . $filename . '">' . $filename . '</a>';
+					$response_form .= '</li>';
+				}
+				$response_form .= "</ul>";
+			}
 
 			// TODO - create a new 'date_with_picker' in tidal_lock/0-5/helpers/class.form.php
 
@@ -562,45 +570,60 @@
 		}
 
 		public function save() {
-			// TODO - Do file uploads saving - deleted files need deleting?
-			// TODO - Remove 'response_uploads' from $this->data?
 			$response_uploads = $this->data['response_uploads'];	
-			print_r($response_uploads);
-			print_r($this->data);
-			print_r("POST:::\n\n\n<br>");
-			print_r($_POST);
-			exit(1);
+			// First delete any files which have been selected for deletion:
+			$this->delete_selected_uploaded_files();
+			// And now move in any new files from the temporary upload directory:
+			$this->save_uploads();
 			unset($this->data['response_uploads']);
 			updateDb('rumours', $this->data, array('rumour_id'=>$this->rumour['rumour_id']), null, null, null, null, 1);
 			$this->data['response_uploads'] = $response_uploads;
+
 
 		}
 
 		public function get_attachments() {
 			global $directory_manager;
 
-			if (file_exists($self->upload_files_dir)) {
-				return $directory_manager->read('uploads/rumour_attachments/' . $self->rumour->public_id, false, false, true);
+			if (file_exists($this->upload_files_dir)) {
+				return $directory_manager->read($this->upload_files_dir , false, false, true);
 			} else {
 				return [];
 			}
 
 		}
 
+
 		public function save_uploads() {
+			global $directory_manager;
+			global $tl;
 			// Uses $_POST directly...
+
 			if (@$_POST['file_response_uploads']) {
 				foreach ($_POST['file_response_uploads'] as $uploadedFile) {
-					$filename = substr($uploadedFile, strrpos($uploadedFile, '/') + 1);
-					$uploadedFile = __DIR__ . '/../../../../' . $uploadedFile;
-					$destinationPath = 'uploads/rumour_response_attachments/' . $this->rumour->public_id;
-					if (!file_exists($destinationPath)) mkdir($destinationPath);
+					$filename = basename($uploadedFile);
+					$uploadedFile = $this->temporary_upload_files_abspath . '/' . $filename;
+					$destinationPath = 'uploads/rumour_response_attachments/' . $this->rumour['public_id'];
+
+					// Create directory for this rumour, if required:
+					if (!file_exists($destinationPath)) {
+						mkdir($destinationPath);
+					}
+					// Try to move the file into that directory:
 					$success = rename($uploadedFile, $destinationPath . '/' . $filename);
 					if (!$success || !file_exists($destinationPath . '/' . $filename)) {
 						$tl->page['error'] .= "Unable to retrieve uploaded file for some reason. ";
 					}
 				}
 			}
+		}
+
+		public function delete_selected_uploaded_files() {
+			global $directory_manager;
+			global $tl;
+			// Uses $_POST directly...
+			
+			// TODO - should this actually move them to a trash dir instead of deleting?
 
 			if (file_exists($this->upload_files_dir)) {
 				$attachments = $directory_manager->read($this->upload_files_dir, false, false, true);
@@ -609,15 +632,24 @@
 					for ($counter = 0; $counter < count($attachments); $counter++) {
 						$should_delete_attachment = isset($_POST['delete_response_uploads_' . $counter]);
 						$attachment_filepath = $_POST['delete_response_uploads_filepath_' . $counter];
+						$attachment_filepath = basename($attachment_filepath);
 
-						// TODO - sanity check $attachment_filepath before deleteing.
-						// This should be ONLY the filename - and any `../` type things stripped out,
-						// and instead it should add the $self->upload_files_dir here.
+						if (!strlen($attachment_filepath)) {
+							$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
+							continue;
+						}
+
+						$attachment_filepath = $this->upload_files_dir . $attachment_filepath;
+
+						if (!is_file($attachment_filepath)) {
+							$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
+							continue;
+						}
 
 						if ($should_delete_attachment) {
 							$success = @unlink ($attachment_filepath);
 							if (!$success || file_exists($attachment_filepath)) {
-								$tl->page['error'] .= "Unable to delete an attachment. " . $attachment_filepath;
+								$tl->page['error'] .= "Unable to delete attachment: " . $attachment_filepath;
 							}
 						}
 					}
@@ -627,5 +659,3 @@
 		}
 
 	}
-		
-?>

--- a/source/web_root/includes/views/desktop/custom/rumour.php
+++ b/source/web_root/includes/views/desktop/custom/rumour.php
@@ -5,7 +5,7 @@
 		echo "  <li" . ($filters['view'] == 'rumour' ? " class='active'" : false) . "><a href='#rumour' data-toggle='tab'>Rumour</a></li>\n";
 		echo "  <li" . ($filters['view'] == 'sightings' ? " class='active'" : false) . "><a href='#sightings' data-toggle='tab' onClick='if (!mapLoaded) populateMap();'>Sightings (" . count($sightings) . ")</a></li>\n";
 		echo "  <li" . ($filters['view'] == 'comments' ? " class='active'" : false) . "><a href='#comments' data-toggle='tab'>Comments" . (@$numberOfComments ? " (" . $numberOfComments . ")" : false) . "</a></li>\n";
-		echo "  <li" . ($filters['view'] == 'response' ? " class='active'" : false) . "><a href='#response' data-toggle='tab'>Response" . ($responseForm->is_valid()?'':'❗️'). "</a></li>";
+		echo "  <li" . ($filters['view'] == 'response' ? " class='active'" : false) . "><a href='#response' data-toggle='tab'>Follow Up" . ($responseForm->is_valid()?'':'❗️'). "</a></li>";
 		echo "</ul><br />\n\n";
 
 	echo "<div class='tab-content'>\n";

--- a/source/web_root/includes/views/desktop/custom/rumour.php
+++ b/source/web_root/includes/views/desktop/custom/rumour.php
@@ -1,11 +1,24 @@
 <?php
 
 	// tabs
+	if (!$responseForm->is_empty()) {
+		if ($responseForm->is_valid()) {
+			if ($responseForm->data['response_completed']) {
+				$response_tab_suffix = '(✔️)';
+			} else {
+				$response_tab_suffix = '(*)';
+			}
+		} else {
+			$response_tab_suffix = '(❗️)';
+		}
+	} else {
+		$response_tab_suffix = '';
+	}
 		echo "<ul id='rumourTabs' class='nav nav-tabs'>\n";
 		echo "  <li" . ($filters['view'] == 'rumour' ? " class='active'" : false) . "><a href='#rumour' data-toggle='tab'>Rumour</a></li>\n";
 		echo "  <li" . ($filters['view'] == 'sightings' ? " class='active'" : false) . "><a href='#sightings' data-toggle='tab' onClick='if (!mapLoaded) populateMap();'>Sightings (" . count($sightings) . ")</a></li>\n";
 		echo "  <li" . ($filters['view'] == 'comments' ? " class='active'" : false) . "><a href='#comments' data-toggle='tab'>Comments" . (@$numberOfComments ? " (" . $numberOfComments . ")" : false) . "</a></li>\n";
-		echo "  <li" . ($filters['view'] == 'response' ? " class='active'" : false) . "><a href='#response' data-toggle='tab'>Follow Up" . ($responseForm->is_valid()?'':'❗️'). "</a></li>";
+		echo "  <li" . ($filters['view'] == 'response' ? " class='active'" : false) . "><a href='#response' data-toggle='tab'>Follow Up " . $response_tab_suffix . "</a></li>";
 		echo "</ul><br />\n\n";
 
 	echo "<div class='tab-content'>\n";


### PR DESCRIPTION
# References

https://app.forecast.it/project/P-211/workflow/T12611
https://app.forecast.it/project/P-211/workflow/T11787

# Description:

- Adds in file uploads (attachments) for the response tab
- Minor styling tweaks to that form
- Various feedback / simplification tweaks from Jake
- Other fixes

Attachments are using the same multi-file upload box (which for users is actually really nice) as the rest of the site - but moving the functionality into the form.  It was a bit fiddly to get working, but works really nicely now.