### PR TITLE
[WIP] Use only one location for rumour adding.

### DIFF
--- a/source/web_root/includes/controllers/custom/rumour_add.php
+++ b/source/web_root/includes/controllers/custom/rumour_add.php
@@ -116,8 +116,6 @@
 			// check for errors
 				if (!$_POST['description']) $tl->page['error'] .= "Please enter a rumour. ";
 				if (!$_POST['country']) $tl->page['error'] .= "Please specify the country where occurred. ";
-				/* if (!$_POST['country_heard']) $tl->page['error'] .= "Please specify the country where heard. "; */
-				/* if (!$_POST['heard_on']) $tl->page['error'] .= "Please specify the date heard. "; */
 				
 				if ($logged_in['is_proxy']) {
 					if (!$_POST['heard_by']) $tl->page['error'] .= "On whose behalf is this rumour created? ";

--- a/source/web_root/includes/controllers/custom/rumour_add.php
+++ b/source/web_root/includes/controllers/custom/rumour_add.php
@@ -116,8 +116,8 @@
 			// check for errors
 				if (!$_POST['description']) $tl->page['error'] .= "Please enter a rumour. ";
 				if (!$_POST['country']) $tl->page['error'] .= "Please specify the country where occurred. ";
-				if (!$_POST['country_heard']) $tl->page['error'] .= "Please specify the country where heard. ";
-				if (!$_POST['heard_on']) $tl->page['error'] .= "Please specify the date heard. ";
+				/* if (!$_POST['country_heard']) $tl->page['error'] .= "Please specify the country where heard. "; */
+				/* if (!$_POST['heard_on']) $tl->page['error'] .= "Please specify the date heard. "; */
 				
 				if ($logged_in['is_proxy']) {
 					if (!$_POST['heard_by']) $tl->page['error'] .= "On whose behalf is this rumour created? ";
@@ -185,9 +185,30 @@
 								}
 
 							// add rumour
-								$rumourID = insertIntoDb('rumours', array('public_id'=>$newRumourPublicID, 'description'=>$_POST['description'], 'country_id'=>$_POST['country'], 'city'=>$_POST['city'], 'latitude'=>$_POST['occurred_at_latitude'], 'longitude'=>$_POST['occurred_at_longitude'], 'occurred_on'=>$_POST['occurred_on'], 'created_by'=>$heardBy, 'created_on'=>date('Y-m-d H:i:s'), 'updated_by'=>$logged_in['user_id'], 'updated_on'=>date('Y-m-d H:i:s'), 'entered_by'=>$logged_in['user_id'], 'status_id'=>@$_POST['status_id'], 'priority_id'=>@$_POST['priority_id'], 'assigned_to'=>@$_POST['assigned_to'], 'domain_alias_id'=>@$tl->page['domain_alias']['cms_id']));
-								if (!$rumourID) $tl->page['error'] .= "Unable to add rumour for some reason. ";
-								else {
+								$rumourID = insertIntoDb(
+									'rumours',
+									array(
+										'public_id'=>$newRumourPublicID,
+										'description'=>$_POST['description'],
+										'country_id'=>$_POST['country'],
+										'city'=>$_POST['city'],
+										'latitude'=>$_POST['occurred_at_latitude'],
+										'longitude'=>$_POST['occurred_at_longitude'],
+										'occurred_on'=>$_POST['occurred_on'],
+										'created_by'=>$heardBy,
+										'created_on'=>date('Y-m-d H:i:s'),
+										'updated_by'=>$logged_in['user_id'],
+										'updated_on'=>date('Y-m-d H:i:s'),
+										'entered_by'=>$logged_in['user_id'],
+										'status_id'=>@$_POST['status_id'],
+										'priority_id'=>@$_POST['priority_id'],
+										'assigned_to'=>@$_POST['assigned_to'],
+										'domain_alias_id'=>@$tl->page['domain_alias']['cms_id']
+									)
+								);
+								if (!$rumourID) {
+								   	$tl->page['error'] .= "Unable to add rumour for some reason. ";
+								} else {
 			
 /*
 									REMOVING FAUX GEOCODING:
@@ -227,7 +248,25 @@
 						if (!count($latLong)) $latLong = retrieveSingleFromDB('rumours', null, array('country_id'=>@$_POST['country_heard'], 'city'=>@$_POST['city_heard']), null, null, null, "latitude <> 0 AND longitude <> 0");
 */
 
-						$sightingID = insertIntoDb('rumour_sightings', array('public_id'=>$newSightingPublicID, 'created_by'=>$heardBy, 'rumour_id'=>$operators->firstTrue(@$rumourID, @$rumour[0]['rumour_id']), 'entered_by'=>$logged_in['user_id'], 'entered_on'=>date('Y-m-d H:i:s'), 'heard_on'=>$_POST['heard_on'], 'country_id'=>@$_POST['country_heard'], 'city'=>@$_POST['city_heard'], 'latitude'=>@$_POST['heard_at_latitude'], 'longitude'=>@$_POST['heard_at_longitude'], 'location_type'=>$_POST['location_type'], 'source_id'=>@$_POST['source_id'], 'ipv4'=>@$ipv4, 'ipv6'=>@$ipv6));
+						$sightingID = insertIntoDb(
+							'rumour_sightings',
+							array(
+								'public_id'=>$newSightingPublicID,
+								'created_by'=>$heardBy,
+								'rumour_id'=>$operators->firstTrue(@$rumourID, @$rumour[0]['rumour_id']),
+								'entered_by'=>$logged_in['user_id'],
+								'entered_on'=>date('Y-m-d H:i:s'),
+								'heard_on'=>$_POST['occurred_on'],
+								'country_id'=>@$_POST['country_heard'],
+								'city'=>@$_POST['city'],
+								'latitude'=>@$_POST['occurred_at_latitude'],
+								'longitude'=>@$_POST['occurred_at_longitude'],
+								'location_type'=>$_POST['location_type'],
+								'source_id'=>@$_POST['source_id'],
+								'ipv4'=>@$ipv4,
+								'ipv6'=>@$ipv6
+							)
+						);
 				
 					// automatically watchlist rumour on behalf of creator
 						deleteFromDbSingle('watchlist', array('rumour_id'=>$operators->firstTrue(@$rumourID, @$rumour[0]['rumour_id']), 'created_by'=>$heardBy));

--- a/source/web_root/includes/views/desktop/shared/add_or_edit_rumour.php
+++ b/source/web_root/includes/views/desktop/shared/add_or_edit_rumour.php
@@ -75,7 +75,13 @@
 								else echo $form->row('uneditable_static', 'country', @$rumour[0]['country'], false, 'Country occurred');
 	/* Area occurred */			if (($tl->page['template'] == 'rumour_add' && !$matchingRumour) || ($tl->page['template'] == 'rumour_edit' && $logged_in['is_administrator'] && $logged_in['can_edit_content'])) {
 									echo $form->row('text', 'city', $operators->firstTrue(@$_POST['city'], @$rumour[0]['city']), false, 'Area occurred', 'form-control', null, 50);
-									echo $form->row('latlongmap', 'occurred_at', $operators->firstTrue((floatval(@$_POST['occurred_at_latitude']) <> 0 || floatval(@$_POST['occurred_at_longitude']) <> 0 ? floatval(@$_POST['occurred_at_latitude']) . "," . floatval(@$_POST['occurred_at_longitude']) : false), (floatval(@$rumour[0]['latitude']) <> 0 && floatval(@$rumour[0]['longitude']) <> 0 ? $rumour[0]['latitude'] . "," . $rumour[0]['longitude'] : false), ($tl->page['template'] == 'rumour_add' && @$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)));
+									echo $form->row('latlongmap', 'occurred_at',
+										$operators->firstTrue(
+											(floatval(@$_POST['occurred_at_latitude']) <> 0 || floatval(@$_POST['occurred_at_longitude']) <> 0 ? floatval(@$_POST['occurred_at_latitude']) . "," . floatval(@$_POST['occurred_at_longitude']) : false),
+											(floatval(@$rumour[0]['latitude']) <> 0 && floatval(@$rumour[0]['longitude']) <> 0 ? $rumour[0]['latitude'] . "," . $rumour[0]['longitude'] : false),
+											($tl->page['template'] == 'rumour_add' && @$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)
+										)
+									);
 								}
 								else echo $form->row('uneditable_static', 'city', @$rumour[0]['city'], false, 'Area occurred');
 	/* Occurred on */			if (($tl->page['template'] == 'rumour_add' && !$matchingRumour) || ($tl->page['template'] == 'rumour_edit' && $logged_in['is_administrator'] && $logged_in['can_edit_content'])) echo $form->row('datetime_with_picker', 'occurred_on', $operators->firstTrue(@$_POST['occurred_on'], @$rumour[0]['occurred_on']), false, 'Occurred on', 'form-control');
@@ -83,11 +89,11 @@
 								else echo $form->row('uneditable_static', 'occurred_on', date('F j, Y', strtotime(@$rumour[0]['occurred_on'])), false, 'Occurred on');
 								
 								if ($tl->page['template'] == 'rumour_add') {
-									/* Country heard */		echo $form->row('country', 'country_heard', $operators->firstTrue(@$_POST['country_heard'], @$_POST['country']), false, 'Country heard', 'form-control');
-									/* Area heard */		echo $form->row('text', 'city_heard', @$_POST['city_heard'], false, 'Area heard', 'form-control', null, 50);
-															echo $form->row('latlongmap', 'heard_at', $operators->firstTrue((floatval(@$_POST['heard_at_latitude']) <> 0 || floatval(@$_POST['heard_at_longitude']) <> 0 ? floatval(@$_POST['heard_at_latitude']) . "," . floatval(@$_POST['heard_at_longitude']) : false), (@$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)));
-									/* Heard on */			echo $form->row('datetime_with_picker', 'heard_on', @$_POST['heard_on'], false, 'Heard on', 'form-control');
-									/* Location type */		echo $form->row('select', 'location_type', @$_POST['location_type'], false, 'Overheard at', 'select2', $locationTypes, null, array('data-placeholder'=>'Overheard at', 'data-tags'=>'true'));
+									/* /1* Country heard *1/		echo $form->row('country', 'country_heard', $operators->firstTrue(@$_POST['country_heard'], @$_POST['country']), false, 'Country heard', 'form-control'); */
+									/* Area heard */ //		echo $form->row('text', 'city_heard', @$_POST['city_heard'], false, 'Area heard', 'form-control', null, 50);
+													 //		echo $form->row('latlongmap', 'heard_at', $operators->firstTrue((floatval(@$_POST['heard_at_latitude']) <> 0 || floatval(@$_POST['heard_at_longitude']) <> 0 ? floatval(@$_POST['heard_at_latitude']) . "," . floatval(@$_POST['heard_at_longitude']) : false), (@$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)));
+									/* /1* Heard on *1/			echo $form->row('datetime_with_picker', 'heard_on', @$_POST['heard_on'], false, 'Heard on', 'form-control'); */
+									/* /1* Location type *1/		echo $form->row('select', 'location_type', @$_POST['location_type'], false, 'Overheard at', 'select2', $locationTypes, null, array('data-placeholder'=>'Overheard at', 'data-tags'=>'true')); */
 								}
 
 	if ($tl->page['template'] == 'rumour_add' && $logged_in['is_proxy']) {

--- a/source/web_root/includes/views/desktop/shared/add_or_edit_rumour.php
+++ b/source/web_root/includes/views/desktop/shared/add_or_edit_rumour.php
@@ -75,13 +75,7 @@
 								else echo $form->row('uneditable_static', 'country', @$rumour[0]['country'], false, 'Country occurred');
 	/* Area occurred */			if (($tl->page['template'] == 'rumour_add' && !$matchingRumour) || ($tl->page['template'] == 'rumour_edit' && $logged_in['is_administrator'] && $logged_in['can_edit_content'])) {
 									echo $form->row('text', 'city', $operators->firstTrue(@$_POST['city'], @$rumour[0]['city']), false, 'Area occurred', 'form-control', null, 50);
-									echo $form->row('latlongmap', 'occurred_at',
-										$operators->firstTrue(
-											(floatval(@$_POST['occurred_at_latitude']) <> 0 || floatval(@$_POST['occurred_at_longitude']) <> 0 ? floatval(@$_POST['occurred_at_latitude']) . "," . floatval(@$_POST['occurred_at_longitude']) : false),
-											(floatval(@$rumour[0]['latitude']) <> 0 && floatval(@$rumour[0]['longitude']) <> 0 ? $rumour[0]['latitude'] . "," . $rumour[0]['longitude'] : false),
-											($tl->page['template'] == 'rumour_add' && @$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)
-										)
-									);
+									echo $form->row('latlongmap', 'occurred_at', $operators->firstTrue((floatval(@$_POST['occurred_at_latitude']) <> 0 || floatval(@$_POST['occurred_at_longitude']) <> 0 ? floatval(@$_POST['occurred_at_latitude']) . "," . floatval(@$_POST['occurred_at_longitude']) : false), (floatval(@$rumour[0]['latitude']) <> 0 && floatval(@$rumour[0]['longitude']) <> 0 ? $rumour[0]['latitude'] . "," . $rumour[0]['longitude'] : false), ($tl->page['template'] == 'rumour_add' && @$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)));
 								}
 								else echo $form->row('uneditable_static', 'city', @$rumour[0]['city'], false, 'Area occurred');
 	/* Occurred on */			if (($tl->page['template'] == 'rumour_add' && !$matchingRumour) || ($tl->page['template'] == 'rumour_edit' && $logged_in['is_administrator'] && $logged_in['can_edit_content'])) echo $form->row('datetime_with_picker', 'occurred_on', $operators->firstTrue(@$_POST['occurred_on'], @$rumour[0]['occurred_on']), false, 'Occurred on', 'form-control');

--- a/source/web_root/includes/views/desktop/shared/add_or_edit_rumour.php
+++ b/source/web_root/includes/views/desktop/shared/add_or_edit_rumour.php
@@ -88,14 +88,6 @@
 								elseif (@$rumour[0]['occurred_on'] == '0000-00-00 00:00:00') echo $form->row('uneditable_static', 'occurred_on', 'Unknown', false, 'Occurred on');
 								else echo $form->row('uneditable_static', 'occurred_on', date('F j, Y', strtotime(@$rumour[0]['occurred_on'])), false, 'Occurred on');
 								
-								if ($tl->page['template'] == 'rumour_add') {
-									/* /1* Country heard *1/		echo $form->row('country', 'country_heard', $operators->firstTrue(@$_POST['country_heard'], @$_POST['country']), false, 'Country heard', 'form-control'); */
-									/* Area heard */ //		echo $form->row('text', 'city_heard', @$_POST['city_heard'], false, 'Area heard', 'form-control', null, 50);
-													 //		echo $form->row('latlongmap', 'heard_at', $operators->firstTrue((floatval(@$_POST['heard_at_latitude']) <> 0 || floatval(@$_POST['heard_at_longitude']) <> 0 ? floatval(@$_POST['heard_at_latitude']) . "," . floatval(@$_POST['heard_at_longitude']) : false), (@$tl->page['domain_alias']['latitude'] <> 0 && @$tl->page['domain_alias']['longitude'] <> 0 ? @$tl->page['domain_alias']['latitude'] . ',' . @$tl->page['domain_alias']['longitude']: false)));
-									/* /1* Heard on *1/			echo $form->row('datetime_with_picker', 'heard_on', @$_POST['heard_on'], false, 'Heard on', 'form-control'); */
-									/* /1* Location type *1/		echo $form->row('select', 'location_type', @$_POST['location_type'], false, 'Overheard at', 'select2', $locationTypes, null, array('data-placeholder'=>'Overheard at', 'data-tags'=>'true')); */
-								}
-
 	if ($tl->page['template'] == 'rumour_add' && $logged_in['is_proxy']) {
 		/* Source */			echo $form->row('select', 'source_id', @$_POST['source_id'], true, 'Reported via', 'form-control', $rumourSources) . "\n";
 		/* On behalf of */		echo $form->rowStart('on_behalf_of', "Reported on behalf of");


### PR DESCRIPTION
# References

https://app.forecast.it/project/P-211/workflow/T14505

# Description

There were 2 location inputs on the create-new-rumour form.

The first one "Rumour Occurred" saves data to the Rumour.

The second one "Rumour Heard" creates the initial "sighting" of the rumour.

This PR combines them - dropping the second one, and creating the initial sighting from the same location as the rumour itself.